### PR TITLE
Following enhancements added: 06/17/2019

### DIFF
--- a/aib_lib/c3aibadapt/rtl/c3aibadapt.v
+++ b/aib_lib/c3aibadapt/rtl/c3aibadapt.v
@@ -300,6 +300,8 @@ module c3aibadapt (
   output wire                       o_xcvrif_core_clk,
   input  wire [2:0]                 i_chnl_fsr,
   input  wire [64:0]                i_chnl_ssr,
+  output wire [80:0]                ms_sideband,
+  output wire [72:0]                sl_sideband,
 
 // EHIP FSR/SSR
   input  wire                       i_rx_ehip_clk,
@@ -861,6 +863,8 @@ assign fpll_shared_direct_async[3] = tb_direct_async[1];
 assign fpll_shared_direct_async[2] = tb_direct_async[1];
 assign fpll_shared_direct_async[1] = tb_direct_async[0];
 assign fpll_shared_direct_async[0] = tb_direct_async[0];
+
+assign sl_sideband = {rx_ssr_parity_checker_in[35:32], rx_ssr_parity_checker_in[30],tx_ssr_parity_checker_in[35:32], rx_ssr_parity_checker_in[31], rx_ssr_parity_checker_in[29:0], tx_ssr_parity_checker_in[31:0]};
 
 c3aibadapt_txchnl adapt_txchnl   (/*AUTOINST*/
        // Outputs
@@ -1666,6 +1670,7 @@ c3aibadapt_avmm adapt_avmm   (/*AUTOINST*/
 
 c3aibadapt_sr adapt_sr (
        // Outputs
+       .ms_sideband                                   (ms_sideband[80:0]), 
        .sr_testbus                                    (sr_testbus),
        .aib_hssi_tx_sr_clk_out                        (o_aib_tx_sr_clk),
        .aib_hssi_fsr_data_out                         (o_aib_fsr_data),

--- a/aib_lib/c3aibadapt/rtl/c3aibadapt_sr/c3aibadapt_sr.v
+++ b/aib_lib/c3aibadapt/rtl/c3aibadapt_sr/c3aibadapt_sr.v
@@ -110,6 +110,7 @@ module c3aibadapt_sr (
   output wire           rx_async_hssi_fabric_fsr_load,  // For capture logic
   output wire           rx_async_hssi_fabric_ssr_load,  // For capture logic
   output wire   [5:0]   sr_parity_error_flag,
+  output wire  [80:0]   ms_sideband,
   
   // TX_ASYNC
   output wire		tx_async_fabric_hssi_fsr_data,
@@ -142,6 +143,8 @@ localparam NUM_OF_PARITY_BIT_FSROUT = 7'd1;
 wire [(NUM_OF_PCS_CHAIN_SSRIN  + NUM_OF_HIP_CHAIN_SSRIN  + NUM_OF_RESERVED_CHAIN_SSRIN  - 1):0]   ssrin_parallel_in;
 wire [(NUM_OF_PCS_CHAIN_SSRIN  + NUM_OF_HIP_CHAIN_SSRIN  + NUM_OF_RESERVED_CHAIN_SSRIN  - 1):0]   ssrin_parallel_in_temp;
 wire [NUM_OF_PARITY_BIT_SSRIN-1:0] ssrin_parity_out;
+
+assign ms_sideband = ssrin_parallel_in[80:0];
 
 wire [(NUM_OF_PCS_CHAIN_SSROUT + NUM_OF_HIP_CHAIN_SSROUT + NUM_OF_RESERVED_CHAIN_SSROUT - 1):0] ssrout_parallel_out;
 wire [(NUM_OF_PCS_CHAIN_SSROUT + NUM_OF_RESERVED_CHAIN_SSROUT - 1):0] ssrout_parity_checker;

--- a/aib_lib/c3aibadapt_wrap/rtl/aib_top.v
+++ b/aib_lib/c3aibadapt_wrap/rtl/aib_top.v
@@ -68,7 +68,12 @@ module aib_top
    output [TOTAL_CHNL_NUM-1:0]                                    o_tx_transfer_clk, // clock used for tx data transmission
    output [TOTAL_CHNL_NUM-1:0]                                    o_tx_transfer_div2_clk, // half rate of tx data transmission clock
    output [TOTAL_CHNL_NUM*40-1:0]                                 o_tx_pma_data, // Directed bump tx data sync path
-
+ //=================================================================================================
+ // AIB open source IP enhancement. The following ports are added to
+ // be compliance with AIB specification 1.1
+   input  [TOTAL_CHNL_NUM-1:0]                                    ns_mac_rdy,  //From Mac. To indicate MAC is ready to send and receive //     data. use aibio49
+   output [TOTAL_CHNL_NUM*81-1:0]                                 ms_sideband, //Status of serial shifting bit from this master chiplet to slave chiplet
+   output [TOTAL_CHNL_NUM*73-1:0]                                 sl_sideband, //Status of serial shifting bit from slave chiplet to master chiplet.
    //=================================================================================================
    // Inout signals for AIB ubump
    inout [95:0]                                                   io_aib_ch0, 
@@ -216,6 +221,9 @@ module aib_top
        .o_tx_transfer_clk               (o_tx_transfer_clk[TOTAL_CHNL_NUM-1:0]),
        .o_tx_transfer_div2_clk          (o_tx_transfer_div2_clk[TOTAL_CHNL_NUM-1:0]),
        .o_tx_pma_data                   (o_tx_pma_data[TOTAL_CHNL_NUM*40-1:0]),
+       .ns_mac_rdy                      (ns_mac_rdy[TOTAL_CHNL_NUM-1:0]),
+       .ms_sideband                     (ms_sideband[TOTAL_CHNL_NUM*81-1:0]),
+       .sl_sideband                     (sl_sideband[TOTAL_CHNL_NUM*73-1:0]),
        .o_test_c3adapt_scan_out         (o_test_c3adapt_scan_out/*[TOTAL_CHNL_NUM-1:0][`AIBADAPTWRAPTCB_SCAN_CHAINS_RNG]*/),
        .o_test_c3adapttcb_jtag          (),                      // Templated
        .o_jtag_last_bs_chain_out        (aibaux_last_bs_in),     // Templated

--- a/aib_lib/c3aibadapt_wrap/rtl/c3aibadapt_wrap.v
+++ b/aib_lib/c3aibadapt_wrap/rtl/c3aibadapt_wrap.v
@@ -88,6 +88,11 @@ module c3aibadapt_wrap
     output [39:0]                              o_tx_pma_data, // Directed bump tx data sync path
 
  //=================================================================================================
+ //AIB open source IP enhancement. The following ports are added to b compliance with AIB specification 1.1
+    input                                      ns_mac_rdy,  //From Mac. To indicate MAC is ready to send and receive data. use aibio49
+    output [80:0]                              ms_sideband, //Status of serial shifting bit from this master chiplet to slave chiplet
+    output [72:0]                              sl_sideband, //Status of serial shifting bit from slave chiplet to master chiplet.                                                      
+ //=================================================================================================
  //// EMIB, AIB IO bumps
  
     inout                                      io_aib0, 
@@ -279,6 +284,20 @@ module c3aibadapt_wrap
     input [12:0]                               i_aibdftdll2adjch, // DCC/DLL observability from previous channel
     output [12:0]                              o_aibdftdll2adjch  // DCC/DLL observability Go to next channel 
  );
+
+    //List the detail bit assignment corresponding to the AIB spec 1.1
+    wire ms_osc_transfer_en = ms_sideband[80];
+    wire ms_tx_transfer_en = ms_sideband[78];
+    wire ms_rx_transfer_en = ms_sideband[75];
+    wire ms_rx_dll_lock = ms_sideband[74];
+    wire ms_tx_dcc_cal_done = ms_sideband[68];
+    wire sl_osc_transfer_en = sl_sideband[72]; 
+    wire sl_rx_transfer_en = sl_sideband[70];
+    wire sl_rx_dll_dcc_lock_req = sl_sideband[69];
+    wire sl_rx_dll_lock = sl_sideband[69];
+    wire sl_tx_transfer_en = sl_sideband[64];
+    wire sl_tx_dll_dcc_lock_req = sl_sideband[63];
+    wire sl_tx_dcc_cal_done = sl_sideband[31];
  
     /*AUTOWIRE*/
     // Beginning of automatic wires (for undeclared instantiated-module outputs)
@@ -589,7 +608,8 @@ module c3aibadapt_wrap
 
     .i_rx_elane_clk                         (1'b1),
     .i_tx_elane_clk                         (1'b1),
-    .i_rx_pma_div66_clk                     (1'b1),
+ // .i_rx_pma_div66_clk                     (1'b1),
+    .i_rx_pma_div66_clk                     (ns_mac_rdy),    //Added for AIB spec 1.1 enhancement. 6/12/19
     .i_tx_pma_div66_clk                     (1'b1),
     .i_rx_ehip_clk                          (1'b1),
      
@@ -752,6 +772,8 @@ module c3aibadapt_wrap
                            .o_tx_elane_rst_n    (),              // Templated
                            .o_chnl_ssr          (o_chnl_ssr[60:0]),
                            .o_chnl_fsr          (),              // Templated
+                           .ms_sideband         (ms_sideband[80:0]),
+                           .sl_sideband         (sl_sideband[72:0]),
                            .o_xcvrif_core_clk   (),              // Templated
                            .o_rx_xcvrif_rst_n   (o_rx_xcvrif_rst_n), // Templated
                            .o_rsvd_direct_async (),              // Templated
@@ -760,7 +782,7 @@ module c3aibadapt_wrap
                            .o_tx_transfer_div2_clk(o_tx_transfer_div2_clk),
                            // Inputs
                            .i_aib_rx_adpt_rst_n (aib_rx_adpt_rst_n), // Templated
-                           .i_aib_tx_adpt_rst_n (aib_tx_adpt_rst_n), // Templated
+                           .i_aib_tx_adpt_rst_n (aib_rx_adpt_rst_n), // Edit 6/16/19 Enhancement request: use only 1 AIB signal for resetting AIB adapter  
                            .i_aib_avmm1_data    (aib_adpt_avmm1_data[1:0]), // Templated
                            .i_aib_avmm2_data    (aib_adpt_avmm2_data[1:0]), // Templated
                            .i_aib_shared_direct_async(shared_direct_async_out[2:0]), // Templated

--- a/aib_lib/c3aibadapt_wrap/rtl/c3aibadapt_wrap_top.v
+++ b/aib_lib/c3aibadapt_wrap/rtl/c3aibadapt_wrap_top.v
@@ -71,6 +71,12 @@ module c3aibadapt_wrap_top
    output [TOTAL_CHNL_NUM-1:0]                                    o_tx_transfer_div2_clk, // half rate of tx data transmission clock
    output [TOTAL_CHNL_NUM*40-1:0]                                 o_tx_pma_data, // Directed bump tx data sync path
 
+ //=================================================================================================
+ //AIB open source IP enhancement. The following ports are added to
+ //be compliance with AIB specification 1.1
+   input  [TOTAL_CHNL_NUM-1:0]                                    ns_mac_rdy,  //From Mac. To indicate MAC is ready to send and receive data. use aibio49
+   output [TOTAL_CHNL_NUM*81-1:0]                                 ms_sideband, //Status of serial shifting bit from this master chiplet to slave chiplet
+   output [TOTAL_CHNL_NUM*73-1:0]                                 sl_sideband, //Status of serial shifting bit from slave chiplet to master chiplet.
    //=================================================================================================
    // Inout signals for AIB ubump
    inout [95:0]                                                   io_aib_ch0, 
@@ -531,6 +537,9 @@ module c3aibadapt_wrap_top
                                     .o_tx_transfer_clk  (o_tx_transfer_clk[0]), // Templated
                                     .o_tx_transfer_div2_clk(o_tx_transfer_div2_clk[0]), // Templated
                                     .o_tx_pma_data      (o_tx_pma_data[39:0]), // Templated
+                                    .ns_mac_rdy         (ns_mac_rdy[0]),
+                                    .ms_sideband        (ms_sideband[80:0]),
+                                    .sl_sideband        (sl_sideband[72:0]),
                                     .o_test_c3adapt_scan_out(o_test_c3adapt_scan_out[0][`AIBADAPTWRAPTCB_SCAN_CHAINS_RNG]), // Templated
                                     .o_test_c3adapttcb_jtag(o_test_c3adapttcb_jtag[0][`AIBADAPTWRAPTCB_JTAG_OUT_RNG]), // Templated
                                     .o_jtag_clkdr_out   (aib_jtag_clkdr_out[0]), // Templated
@@ -691,6 +700,9 @@ module c3aibadapt_wrap_top
                                     .o_tx_transfer_clk  (o_tx_transfer_clk[1]), // Templated
                                     .o_tx_transfer_div2_clk(o_tx_transfer_div2_clk[1]), // Templated
                                     .o_tx_pma_data      (o_tx_pma_data[79:40]), // Templated
+                                    .ns_mac_rdy         (ns_mac_rdy[1]),
+                                    .ms_sideband        (ms_sideband[161:81]),
+                                    .sl_sideband        (sl_sideband[145:73]),
                                     .o_test_c3adapt_scan_out(o_test_c3adapt_scan_out[1][`AIBADAPTWRAPTCB_SCAN_CHAINS_RNG]), // Templated
                                     .o_test_c3adapttcb_jtag(o_test_c3adapttcb_jtag[1][`AIBADAPTWRAPTCB_JTAG_OUT_RNG]), // Templated
                                     .o_jtag_clkdr_out   (aib_jtag_clkdr_out[1]), // Templated
@@ -882,6 +894,9 @@ module c3aibadapt_wrap_top
                                     .o_tx_transfer_clk  (o_tx_transfer_clk[2]), // Templated
                                     .o_tx_transfer_div2_clk(o_tx_transfer_div2_clk[2]), // Templated
                                     .o_tx_pma_data      (o_tx_pma_data[119:80]), // Templated
+                                    .ns_mac_rdy         (ns_mac_rdy[2]),
+                                    .ms_sideband        (ms_sideband[242:162]),
+                                    .sl_sideband        (sl_sideband[218:146]),
                                     .o_test_c3adapt_scan_out(o_test_c3adapt_scan_out[2][`AIBADAPTWRAPTCB_SCAN_CHAINS_RNG]), // Templated
                                     .o_test_c3adapttcb_jtag(o_test_c3adapttcb_jtag[2][`AIBADAPTWRAPTCB_JTAG_OUT_RNG]), // Templated
                                     .o_jtag_clkdr_out   (aib_jtag_clkdr_out[2]), // Templated
@@ -1073,6 +1088,9 @@ module c3aibadapt_wrap_top
                                     .o_tx_transfer_clk  (o_tx_transfer_clk[3]), // Templated
                                     .o_tx_transfer_div2_clk(o_tx_transfer_div2_clk[3]), // Templated
                                     .o_tx_pma_data      (o_tx_pma_data[159:120]), // Templated
+                                    .ns_mac_rdy         (ns_mac_rdy[3]),
+                                    .ms_sideband        (ms_sideband[323:243]),
+                                    .sl_sideband        (sl_sideband[291:219]),
                                     .o_test_c3adapt_scan_out(o_test_c3adapt_scan_out[3][`AIBADAPTWRAPTCB_SCAN_CHAINS_RNG]), // Templated
                                     .o_test_c3adapttcb_jtag(o_test_c3adapttcb_jtag[3][`AIBADAPTWRAPTCB_JTAG_OUT_RNG]), // Templated
                                     .o_jtag_clkdr_out   (aib_jtag_clkdr_out[3]), // Templated
@@ -1264,6 +1282,9 @@ module c3aibadapt_wrap_top
                                     .o_tx_transfer_clk  (o_tx_transfer_clk[4]), // Templated
                                     .o_tx_transfer_div2_clk(o_tx_transfer_div2_clk[4]), // Templated
                                     .o_tx_pma_data      (o_tx_pma_data[199:160]), // Templated
+                                    .ns_mac_rdy         (ns_mac_rdy[4]),
+                                    .ms_sideband        (ms_sideband[404:324]),
+                                    .sl_sideband        (sl_sideband[364:292]),
                                     .o_test_c3adapt_scan_out(o_test_c3adapt_scan_out[4][`AIBADAPTWRAPTCB_SCAN_CHAINS_RNG]), // Templated
                                     .o_test_c3adapttcb_jtag(o_test_c3adapttcb_jtag[4][`AIBADAPTWRAPTCB_JTAG_OUT_RNG]), // Templated
                                     .o_jtag_clkdr_out   (aib_jtag_clkdr_out[4]), // Templated
@@ -1469,6 +1490,9 @@ module c3aibadapt_wrap_top
                                     .o_tx_transfer_clk  (o_tx_transfer_clk[5]), // Templated
                                     .o_tx_transfer_div2_clk(o_tx_transfer_div2_clk[5]), // Templated
                                     .o_tx_pma_data      (o_tx_pma_data[239:200]), // Templated
+                                    .ns_mac_rdy         (ns_mac_rdy[5]),
+                                    .ms_sideband        (ms_sideband[485:405]),
+                                    .sl_sideband        (sl_sideband[437:365]),
                                     .o_test_c3adapt_scan_out(o_test_c3adapt_scan_out[5][`AIBADAPTWRAPTCB_SCAN_CHAINS_RNG]), // Templated
                                     .o_test_c3adapttcb_jtag(o_test_c3adapttcb_jtag[5][`AIBADAPTWRAPTCB_JTAG_OUT_RNG]), // Templated
                                     .o_jtag_clkdr_out   (aib_jtag_clkdr_out[5]), // Templated
@@ -1793,6 +1817,9 @@ module c3aibadapt_wrap_top
                                     .o_tx_transfer_clk  (o_tx_transfer_clk[6]), // Templated
                                     .o_tx_transfer_div2_clk(o_tx_transfer_div2_clk[6]), // Templated
                                     .o_tx_pma_data      (o_tx_pma_data[279:240]), // Templated
+                                    .ns_mac_rdy         (ns_mac_rdy[6]),
+                                    .ms_sideband        (ms_sideband[566:486]),
+                                    .sl_sideband        (sl_sideband[510:438]),
                                     .o_test_c3adapt_scan_out(o_test_c3adapt_scan_out[6][`AIBADAPTWRAPTCB_SCAN_CHAINS_RNG]), // Templated
                                     .o_test_c3adapttcb_jtag(o_test_c3adapttcb_jtag[6][`AIBADAPTWRAPTCB_JTAG_OUT_RNG]), // Templated
                                     .o_jtag_clkdr_out   (aib_jtag_clkdr_out[6]), // Templated
@@ -1963,6 +1990,9 @@ module c3aibadapt_wrap_top
                                     .o_tx_transfer_clk  (o_tx_transfer_clk[7]), // Templated
                                     .o_tx_transfer_div2_clk(o_tx_transfer_div2_clk[7]), // Templated
                                     .o_tx_pma_data      (o_tx_pma_data[319:280]), // Templated
+                                    .ns_mac_rdy         (ns_mac_rdy[7]),
+                                    .ms_sideband        (ms_sideband[647:567]),
+                                    .sl_sideband        (sl_sideband[583:511]),
                                     .o_test_c3adapt_scan_out(o_test_c3adapt_scan_out[7][`AIBADAPTWRAPTCB_SCAN_CHAINS_RNG]), // Templated
                                     .o_test_c3adapttcb_jtag(o_test_c3adapttcb_jtag[7][`AIBADAPTWRAPTCB_JTAG_OUT_RNG]), // Templated
                                     .o_jtag_clkdr_out   (aib_jtag_clkdr_out[7]), // Templated
@@ -2154,6 +2184,9 @@ module c3aibadapt_wrap_top
                                     .o_tx_transfer_clk  (o_tx_transfer_clk[8]), // Templated
                                     .o_tx_transfer_div2_clk(o_tx_transfer_div2_clk[8]), // Templated
                                     .o_tx_pma_data      (o_tx_pma_data[359:320]), // Templated
+                                    .ns_mac_rdy         (ns_mac_rdy[8]),
+                                    .ms_sideband        (ms_sideband[728:648]),
+                                    .sl_sideband        (sl_sideband[656:584]),
                                     .o_test_c3adapt_scan_out(o_test_c3adapt_scan_out[8][`AIBADAPTWRAPTCB_SCAN_CHAINS_RNG]), // Templated
                                     .o_test_c3adapttcb_jtag(o_test_c3adapttcb_jtag[8][`AIBADAPTWRAPTCB_JTAG_OUT_RNG]), // Templated
                                     .o_jtag_clkdr_out   (aib_jtag_clkdr_out[8]), // Templated
@@ -2345,6 +2378,9 @@ module c3aibadapt_wrap_top
                                     .o_tx_transfer_clk  (o_tx_transfer_clk[9]), // Templated
                                     .o_tx_transfer_div2_clk(o_tx_transfer_div2_clk[9]), // Templated
                                     .o_tx_pma_data      (o_tx_pma_data[399:360]), // Templated
+                                    .ns_mac_rdy         (ns_mac_rdy[9]),
+                                    .ms_sideband        (ms_sideband[809:729]),
+                                    .sl_sideband        (sl_sideband[729:657]),
                                     .o_test_c3adapt_scan_out(o_test_c3adapt_scan_out[9][`AIBADAPTWRAPTCB_SCAN_CHAINS_RNG]), // Templated
                                     .o_test_c3adapttcb_jtag(o_test_c3adapttcb_jtag[9][`AIBADAPTWRAPTCB_JTAG_OUT_RNG]), // Templated
                                     .o_jtag_clkdr_out   (aib_jtag_clkdr_out[9]), // Templated
@@ -2536,6 +2572,9 @@ module c3aibadapt_wrap_top
                                      .o_tx_transfer_clk (o_tx_transfer_clk[10]), // Templated
                                      .o_tx_transfer_div2_clk(o_tx_transfer_div2_clk[10]), // Templated
                                      .o_tx_pma_data     (o_tx_pma_data[439:400]), // Templated
+                                     .ns_mac_rdy         (ns_mac_rdy[10]),
+                                     .ms_sideband        (ms_sideband[890:810]),
+                                     .sl_sideband        (sl_sideband[802:730]),
                                      .o_test_c3adapt_scan_out(o_test_c3adapt_scan_out[10][`AIBADAPTWRAPTCB_SCAN_CHAINS_RNG]), // Templated
                                      .o_test_c3adapttcb_jtag(o_test_c3adapttcb_jtag[10][`AIBADAPTWRAPTCB_JTAG_OUT_RNG]), // Templated
                                      .o_jtag_clkdr_out  (aib_jtag_clkdr_out[10]), // Templated
@@ -2741,6 +2780,9 @@ module c3aibadapt_wrap_top
                                      .o_tx_transfer_clk (o_tx_transfer_clk[11]), // Templated
                                      .o_tx_transfer_div2_clk(o_tx_transfer_div2_clk[11]), // Templated
                                      .o_tx_pma_data     (o_tx_pma_data[479:440]), // Templated
+                                     .ns_mac_rdy        (ns_mac_rdy[11]),
+                                     .ms_sideband       (ms_sideband[971:891]),
+                                     .sl_sideband        (sl_sideband[875:803]),
                                      .o_test_c3adapt_scan_out(o_test_c3adapt_scan_out[11][`AIBADAPTWRAPTCB_SCAN_CHAINS_RNG]), // Templated
                                      .o_test_c3adapttcb_jtag(o_test_c3adapttcb_jtag[11][`AIBADAPTWRAPTCB_JTAG_OUT_RNG]), // Templated
                                      .o_jtag_clkdr_out  (aib_jtag_clkdr_out[11]), // Templated
@@ -3014,6 +3056,9 @@ module c3aibadapt_wrap_top
                                      .o_tx_transfer_clk (o_tx_transfer_clk[12]), // Templated
                                      .o_tx_transfer_div2_clk(o_tx_transfer_div2_clk[12]), // Templated
                                      .o_tx_pma_data     (o_tx_pma_data[519:480]), // Templated
+                                     .ns_mac_rdy        (ns_mac_rdy[12]),
+                                     .ms_sideband        (ms_sideband[1052:972]),
+                                     .sl_sideband        (sl_sideband[948:876]),
                                      .o_test_c3adapt_scan_out(o_test_c3adapt_scan_out[12][`AIBADAPTWRAPTCB_SCAN_CHAINS_RNG]), // Templated
                                      .o_test_c3adapttcb_jtag(o_test_c3adapttcb_jtag[12][`AIBADAPTWRAPTCB_JTAG_OUT_RNG]), // Templated
                                      .o_jtag_clkdr_out  (aib_jtag_clkdr_out[12]), // Templated
@@ -3184,6 +3229,9 @@ module c3aibadapt_wrap_top
                                      .o_tx_transfer_clk (o_tx_transfer_clk[13]), // Templated
                                      .o_tx_transfer_div2_clk(o_tx_transfer_div2_clk[13]), // Templated
                                      .o_tx_pma_data     (o_tx_pma_data[559:520]), // Templated
+                                     .ns_mac_rdy        (ns_mac_rdy[13]),
+                                     .ms_sideband        (ms_sideband[1133:1053]),
+                                     .sl_sideband        (sl_sideband[1021:949]),
                                      .o_test_c3adapt_scan_out(o_test_c3adapt_scan_out[13][`AIBADAPTWRAPTCB_SCAN_CHAINS_RNG]), // Templated
                                      .o_test_c3adapttcb_jtag(o_test_c3adapttcb_jtag[13][`AIBADAPTWRAPTCB_JTAG_OUT_RNG]), // Templated
                                      .o_jtag_clkdr_out  (aib_jtag_clkdr_out[13]), // Templated
@@ -3375,6 +3423,9 @@ module c3aibadapt_wrap_top
                                      .o_tx_transfer_clk (o_tx_transfer_clk[14]), // Templated
                                      .o_tx_transfer_div2_clk(o_tx_transfer_div2_clk[14]), // Templated
                                      .o_tx_pma_data     (o_tx_pma_data[599:560]), // Templated
+                                     .ns_mac_rdy        (ns_mac_rdy[14]),
+                                     .ms_sideband        (ms_sideband[1214:1134]),
+                                     .sl_sideband        (sl_sideband[1094:1022]),
                                      .o_test_c3adapt_scan_out(o_test_c3adapt_scan_out[14][`AIBADAPTWRAPTCB_SCAN_CHAINS_RNG]), // Templated
                                      .o_test_c3adapttcb_jtag(o_test_c3adapttcb_jtag[14][`AIBADAPTWRAPTCB_JTAG_OUT_RNG]), // Templated
                                      .o_jtag_clkdr_out  (aib_jtag_clkdr_out[14]), // Templated
@@ -3566,6 +3617,9 @@ module c3aibadapt_wrap_top
                                      .o_tx_transfer_clk (o_tx_transfer_clk[15]), // Templated
                                      .o_tx_transfer_div2_clk(o_tx_transfer_div2_clk[15]), // Templated
                                      .o_tx_pma_data     (o_tx_pma_data[639:600]), // Templated
+                                     .ns_mac_rdy        (ns_mac_rdy[15]),
+                                     .ms_sideband        (ms_sideband[1295:1215]),
+                                     .sl_sideband        (sl_sideband[1167:1095]),
                                      .o_test_c3adapt_scan_out(o_test_c3adapt_scan_out[15][`AIBADAPTWRAPTCB_SCAN_CHAINS_RNG]), // Templated
                                      .o_test_c3adapttcb_jtag(o_test_c3adapttcb_jtag[15][`AIBADAPTWRAPTCB_JTAG_OUT_RNG]), // Templated
                                      .o_jtag_clkdr_out  (aib_jtag_clkdr_out[15]), // Templated
@@ -3757,6 +3811,9 @@ module c3aibadapt_wrap_top
                                      .o_tx_transfer_clk (o_tx_transfer_clk[16]), // Templated
                                      .o_tx_transfer_div2_clk(o_tx_transfer_div2_clk[16]), // Templated
                                      .o_tx_pma_data     (o_tx_pma_data[679:640]), // Templated
+                                     .ns_mac_rdy        (ns_mac_rdy[16]),
+                                     .ms_sideband        (ms_sideband[1376:1296]),
+                                     .sl_sideband        (sl_sideband[1240:1168]),
                                      .o_test_c3adapt_scan_out(o_test_c3adapt_scan_out[16][`AIBADAPTWRAPTCB_SCAN_CHAINS_RNG]), // Templated
                                      .o_test_c3adapttcb_jtag(o_test_c3adapttcb_jtag[16][`AIBADAPTWRAPTCB_JTAG_OUT_RNG]), // Templated
                                      .o_jtag_clkdr_out  (aib_jtag_clkdr_out[16]), // Templated
@@ -3962,6 +4019,9 @@ module c3aibadapt_wrap_top
                                      .o_tx_transfer_clk (o_tx_transfer_clk[17]), // Templated
                                      .o_tx_transfer_div2_clk(o_tx_transfer_div2_clk[17]), // Templated
                                      .o_tx_pma_data     (o_tx_pma_data[719:680]), // Templated
+                                     .ns_mac_rdy        (ns_mac_rdy[17]),
+                                     .ms_sideband        (ms_sideband[1457:1377]),
+                                     .sl_sideband        (sl_sideband[1313:1241]),
                                      .o_test_c3adapt_scan_out(o_test_c3adapt_scan_out[17][`AIBADAPTWRAPTCB_SCAN_CHAINS_RNG]), // Templated
                                      .o_test_c3adapttcb_jtag(o_test_c3adapttcb_jtag[17][`AIBADAPTWRAPTCB_JTAG_OUT_RNG]), // Templated
                                      .o_jtag_clkdr_out  (aib_jtag_clkdr_out[17]), // Templated
@@ -4235,6 +4295,9 @@ module c3aibadapt_wrap_top
                                      .o_tx_transfer_clk (o_tx_transfer_clk[18]), // Templated
                                      .o_tx_transfer_div2_clk(o_tx_transfer_div2_clk[18]), // Templated
                                      .o_tx_pma_data     (o_tx_pma_data[759:720]), // Templated
+                                     .ns_mac_rdy        (ns_mac_rdy[18]),
+                                     .ms_sideband        (ms_sideband[1538:1458]),
+                                     .sl_sideband        (sl_sideband[1386:1314]),
                                      .o_test_c3adapt_scan_out(o_test_c3adapt_scan_out[18][`AIBADAPTWRAPTCB_SCAN_CHAINS_RNG]), // Templated
                                      .o_test_c3adapttcb_jtag(o_test_c3adapttcb_jtag[18][`AIBADAPTWRAPTCB_JTAG_OUT_RNG]), // Templated
                                      .o_jtag_clkdr_out  (aib_jtag_clkdr_out[18]), // Templated
@@ -4405,6 +4468,9 @@ module c3aibadapt_wrap_top
                                      .o_tx_transfer_clk (o_tx_transfer_clk[19]), // Templated
                                      .o_tx_transfer_div2_clk(o_tx_transfer_div2_clk[19]), // Templated
                                      .o_tx_pma_data     (o_tx_pma_data[799:760]), // Templated
+                                     .ns_mac_rdy        (ns_mac_rdy[19]),
+                                     .ms_sideband        (ms_sideband[1619:1539]),
+                                     .sl_sideband        (sl_sideband[1459:1387]),
                                      .o_test_c3adapt_scan_out(o_test_c3adapt_scan_out[19][`AIBADAPTWRAPTCB_SCAN_CHAINS_RNG]), // Templated
                                      .o_test_c3adapttcb_jtag(o_test_c3adapttcb_jtag[19][`AIBADAPTWRAPTCB_JTAG_OUT_RNG]), // Templated
                                      .o_jtag_clkdr_out  (aib_jtag_clkdr_out[19]), // Templated
@@ -4596,6 +4662,9 @@ module c3aibadapt_wrap_top
                                      .o_tx_transfer_clk (o_tx_transfer_clk[20]), // Templated
                                      .o_tx_transfer_div2_clk(o_tx_transfer_div2_clk[20]), // Templated
                                      .o_tx_pma_data     (o_tx_pma_data[839:800]), // Templated
+                                     .ns_mac_rdy        (ns_mac_rdy[20]),
+                                     .ms_sideband        (ms_sideband[1700:1620]),
+                                     .sl_sideband        (sl_sideband[1532:1460]),
                                      .o_test_c3adapt_scan_out(o_test_c3adapt_scan_out[20][`AIBADAPTWRAPTCB_SCAN_CHAINS_RNG]), // Templated
                                      .o_test_c3adapttcb_jtag(o_test_c3adapttcb_jtag[20][`AIBADAPTWRAPTCB_JTAG_OUT_RNG]), // Templated
                                      .o_jtag_clkdr_out  (aib_jtag_clkdr_out[20]), // Templated
@@ -4787,6 +4856,9 @@ module c3aibadapt_wrap_top
                                      .o_tx_transfer_clk (o_tx_transfer_clk[21]), // Templated
                                      .o_tx_transfer_div2_clk(o_tx_transfer_div2_clk[21]), // Templated
                                      .o_tx_pma_data     (o_tx_pma_data[879:840]), // Templated
+                                     .ns_mac_rdy        (ns_mac_rdy[21]),
+                                     .ms_sideband        (ms_sideband[1781:1701]),
+                                     .sl_sideband        (sl_sideband[1605:1533]),
                                      .o_test_c3adapt_scan_out(o_test_c3adapt_scan_out[21][`AIBADAPTWRAPTCB_SCAN_CHAINS_RNG]), // Templated
                                      .o_test_c3adapttcb_jtag(o_test_c3adapttcb_jtag[21][`AIBADAPTWRAPTCB_JTAG_OUT_RNG]), // Templated
                                      .o_jtag_clkdr_out  (aib_jtag_clkdr_out[21]), // Templated
@@ -4978,6 +5050,9 @@ module c3aibadapt_wrap_top
                                      .o_tx_transfer_clk (o_tx_transfer_clk[22]), // Templated
                                      .o_tx_transfer_div2_clk(o_tx_transfer_div2_clk[22]), // Templated
                                      .o_tx_pma_data     (o_tx_pma_data[919:880]), // Templated
+                                     .ns_mac_rdy        (ns_mac_rdy[22]),
+                                     .ms_sideband        (ms_sideband[1862:1782]),
+                                     .sl_sideband        (sl_sideband[1678:1606]),
                                      .o_test_c3adapt_scan_out(o_test_c3adapt_scan_out[22][`AIBADAPTWRAPTCB_SCAN_CHAINS_RNG]), // Templated
                                      .o_test_c3adapttcb_jtag(o_test_c3adapttcb_jtag[22][`AIBADAPTWRAPTCB_JTAG_OUT_RNG]), // Templated
                                      .o_jtag_clkdr_out  (aib_jtag_clkdr_out[22]), // Templated
@@ -5174,6 +5249,9 @@ module c3aibadapt_wrap_top
                                      .o_tx_transfer_clk (o_tx_transfer_clk[23]), // Templated
                                      .o_tx_transfer_div2_clk(o_tx_transfer_div2_clk[23]), // Templated
                                      .o_tx_pma_data     (o_tx_pma_data[959:920]), // Templated
+                                     .ns_mac_rdy        (ns_mac_rdy[23]),
+                                     .ms_sideband        (ms_sideband[1943:1863]),
+                                     .sl_sideband        (sl_sideband[1751:1679]),
                                      .o_test_c3adapt_scan_out(o_test_c3adapt_scan_out[23][`AIBADAPTWRAPTCB_SCAN_CHAINS_RNG]), // Templated
                                      .o_test_c3adapttcb_jtag(o_test_c3adapttcb_jtag[23][`AIBADAPTWRAPTCB_JTAG_OUT_RNG]), // Templated
                                      .o_jtag_clkdr_out  (aib_jtag_clkdr_out[23]), // Templated

--- a/enhancement
+++ b/enhancement
@@ -28,3 +28,11 @@ grep of  i_cfg_avmm_wdata in c3aibadapt_wrap_top.v:
                                     .i_cfg_avmm_wdata   (aib_cfg_avmm_wdata_ch22[31:0]), // Templated
 
 User can get optimized routing by modifying i_cfg_avmm_wdata connection, so that aib_cfg_avmm_wdata_ch0, 1, 2 ... to ch22.
+
+06/17/2019
+1) Use only 1 AIB signal for resetting AIB adapter
+2) Expose ns_mac_rdy as an input at each module port up through aib_top and individual channel.
+3) For all channels [23:0] expose the slave to master incoming shift register at aib_top, PHY-->MAC
+4) For all channels [23:0] expose the master to slave bits corresponding to the outgoing shift registe
+
+

--- a/how2use/sim_aib_top/dut_io.sv
+++ b/how2use/sim_aib_top/dut_io.sv
@@ -2,6 +2,7 @@
 // Copyright (C) 2019 Intel Corporation. All rights reserved
 // ==========================================================================
 
+`timescale 1ps/1ps
 interface dut_io (input bit i_osc_clk, 
 		  input bit i_rx_pma_clk,
                   input bit i_tx_pma_clk,
@@ -9,6 +10,7 @@ interface dut_io (input bit i_osc_clk,
 
   
     logic                        i_adpt_hard_rst_n;
+    logic                        ns_mac_rdy;
     logic [6-1:0]                i_channel_id;
     logic                        i_cfg_avmm_rst_n;
     logic [16:0]                 i_cfg_avmm_addr;
@@ -73,6 +75,7 @@ interface dut_io (input bit i_osc_clk,
 		clocking cb_rx_pma,
                 clocking cb_cfg_avmm,
 		output i_adpt_hard_rst_n,
+                output ns_mac_rdy,
                 output i_cfg_avmm_rst_n);
     
 endinterface // dut_io

--- a/how2use/sim_aib_top/test.sv
+++ b/how2use/sim_aib_top/test.sv
@@ -44,6 +44,7 @@ program automatic test (dut_io.TB dut);
 	begin
 	    dut.i_adpt_hard_rst_n <= 1'b0;
             dut.i_cfg_avmm_rst_n  <= 1'b0;
+            dut.ns_mac_rdy <= 1'b0;
             
             err_count <= 0;
 
@@ -83,7 +84,8 @@ program automatic test (dut_io.TB dut);
 
 
             $display ("[%t] Done configuration", $time);
-            
+            dut.ns_mac_rdy <= 1'b1; 
+            $display ("[%t] ns_mac_rdy is up. Clock should be stable prior to this", $time);
 	    repeat (random_dly_cycle) @ (posedge top.i_osc_clk);            
 	    dut.i_adpt_hard_rst_n <= 1'b1;
 	    $display("%0t: %m: de-asserting adapter hard reset", $time);

--- a/how2use/sim_aib_top/top.sv
+++ b/how2use/sim_aib_top/top.sv
@@ -11,11 +11,6 @@
 
 module top;
 
-    //------------------------------------------------------------------------------------------
-    // Dump control
-    initial begin
-    end
-
 
     //------------------------------------------------------------------------------------------
     // Clock generation
@@ -276,6 +271,10 @@ module top;
     wire                o_tx_xcvrif_rst_n;      // From dut of c3aibadapt_wrap.v
     wire                o_txen_out_chain1;      // From dut of c3aibadapt_wrap.v
     wire                o_txen_out_chain2;      // From dut of c3aibadapt_wrap.v
+    wire                HI;
+    wire                LO;
+    wire  [81*24-1:0]   ms_sideband;
+    wire  [73*24-1:0]   sl_sideband;              
     // End of automatics
    // EMIB Side
 // wire [95:0] AIB_CHAN0;
@@ -1540,27 +1539,30 @@ module top;
 
     aib_top u_aib_top
              (
-                    .i_adpt_hard_rst_n           (dut_io.i_adpt_hard_rst_n), 
+                    .i_adpt_hard_rst_n           (top_io.i_adpt_hard_rst_n), 
                     .o_rx_xcvrif_rst_n           (),   // FIXME
                     .i_cfg_avmm_clk              (i_cfg_avmm_clk), 
-                    .i_cfg_avmm_rst_n            (dut_io.i_cfg_avmm_rst_n), 
-                    .i_cfg_avmm_addr             (dut_io.i_cfg_avmm_addr[16:0]), 
-                    .i_cfg_avmm_byte_en          (dut_io.i_cfg_avmm_byte_en[3:0]), 
-                    .i_cfg_avmm_read             (dut_io.i_cfg_avmm_read), 
-                    .i_cfg_avmm_write            (dut_io.i_cfg_avmm_write), 
-                    .i_cfg_avmm_wdata            (dut_io.i_cfg_avmm_wdata[31:0]), 
+                    .i_cfg_avmm_rst_n            (top_io.i_cfg_avmm_rst_n), 
+                    .i_cfg_avmm_addr             (top_io.i_cfg_avmm_addr[16:0]), 
+                    .i_cfg_avmm_byte_en          (top_io.i_cfg_avmm_byte_en[3:0]), 
+                    .i_cfg_avmm_read             (top_io.i_cfg_avmm_read), 
+                    .i_cfg_avmm_write            (top_io.i_cfg_avmm_write), 
+                    .i_cfg_avmm_wdata            (top_io.i_cfg_avmm_wdata[31:0]), 
                     .o_cfg_avmm_rdatavld         (o_cfg_avmm_rdatavld),
                     .o_cfg_avmm_rdata            (o_cfg_avmm_rdata), 
                     .o_cfg_avmm_waitreq          (o_cfg_avmm_waitreq), 
                     .i_rx_pma_clk                ({24{i_rx_pma_clk}}), 
                     .i_rx_pma_div2_clk           ({24{i_rx_pma_div2_clk}}), 
                     .i_chnl_ssr                  ({65*24{1'b0}}),   // FIXME
-                    .i_rx_pma_data               ({24{dut_io.i_rx_pma_data[39:0]}}), 
+                    .i_rx_pma_data               ({24{top_io.i_rx_pma_data[39:0]}}), 
                     .i_tx_pma_clk                ({24{i_tx_pma_clk}}), 
                     .o_chnl_ssr                  (),        // FIXME 
                     .o_tx_transfer_clk           (o_tx_transfer_clk), 
                     .o_tx_transfer_div2_clk      (o_tx_transfer_div2_clk),        // Not used 
                     .o_tx_pma_data               (o_tx_pma_data_24ch), 
+		    .ns_mac_rdy                  ({24{top_io.ns_mac_rdy}}),
+                    .ms_sideband                 (ms_sideband),
+		    .sl_sideband                 (sl_sideband),
                     .io_aib_ch0                  ({aib95_ch0_x0y0, aib94_ch0_x0y0, 1'b1,          aib94_ch0_x0y0,
                                                    aib91_ch0_x0y0, aib90_ch0_x0y0, aib89_ch0_x0y0,aib88_ch0_x0y0,
                                                    aib87_ch0_x0y0, aib86_ch0_x0y0, aib85_ch0_x0y0,aib84_ch0_x0y0,
@@ -2140,7 +2142,7 @@ module top;
                     .io_aib_aux                  (AIB_AUX),
 //                  .io_aib_aux                  (),
                     .io_aux_bg_ext_2k            (io_aux_bg_ext_2k),
-	            .i_iocsr_rdy_aibaux          (dut_io.i_adpt_hard_rst_n),
+	            .i_iocsr_rdy_aibaux          (top_io.i_adpt_hard_rst_n),
 	            .i_aibaux_por_vccl_ovrd      (1'b1),      
                     .i_aibaux_ctrl_bus0          (32'b0), 
 //                  .i_aibaux_ctrl_bus1          (32'h805001e0),  //observe oosc dft[12:0] 

--- a/how2use/sim_aib_top_ncsim/dut_io.sv
+++ b/how2use/sim_aib_top_ncsim/dut_io.sv
@@ -2,6 +2,7 @@
 // Copyright (C) 2019 Intel Corporation. All rights reserved
 // ==========================================================================
 
+`timescale 1ps/1ps
 interface dut_io (input bit i_osc_clk, 
 		  input bit i_rx_pma_clk,
                   input bit i_tx_pma_clk,
@@ -9,6 +10,7 @@ interface dut_io (input bit i_osc_clk,
 
   
     logic                        i_adpt_hard_rst_n;
+    logic                        ns_mac_rdy;
     logic [6-1:0]                i_channel_id;
     logic                        i_cfg_avmm_rst_n;
     logic [16:0]                 i_cfg_avmm_addr;
@@ -73,6 +75,7 @@ interface dut_io (input bit i_osc_clk,
 		clocking cb_rx_pma,
                 clocking cb_cfg_avmm,
 		output i_adpt_hard_rst_n,
+                output ns_mac_rdy,
                 output i_cfg_avmm_rst_n);
     
 endinterface // dut_io

--- a/how2use/sim_aib_top_ncsim/test.sv
+++ b/how2use/sim_aib_top_ncsim/test.sv
@@ -44,6 +44,7 @@ program automatic test (dut_io.TB dut);
 	begin
 	    dut.i_adpt_hard_rst_n <= 1'b0;
             dut.i_cfg_avmm_rst_n  <= 1'b0;
+            dut.ns_mac_rdy <= 1'b0;
             
             err_count <= 0;
 
@@ -83,7 +84,8 @@ program automatic test (dut_io.TB dut);
 
 
             $display ("[%t] Done configuration", $time);
-            
+            dut.ns_mac_rdy <= 1'b1; 
+            $display ("[%t] ns_mac_rdy is up. Clock should be stable prior to this", $time);
 	    repeat (random_dly_cycle) @ (posedge top.i_osc_clk);            
 	    dut.i_adpt_hard_rst_n <= 1'b1;
 	    $display("%0t: %m: de-asserting adapter hard reset", $time);

--- a/how2use/sim_aib_top_ncsim/top.sv
+++ b/how2use/sim_aib_top_ncsim/top.sv
@@ -11,11 +11,6 @@
 
 module top;
 
-    //------------------------------------------------------------------------------------------
-    // Dump control
-    initial begin
-    end
-
 
     //------------------------------------------------------------------------------------------
     // Clock generation
@@ -276,6 +271,10 @@ module top;
     wire                o_tx_xcvrif_rst_n;      // From dut of c3aibadapt_wrap.v
     wire                o_txen_out_chain1;      // From dut of c3aibadapt_wrap.v
     wire                o_txen_out_chain2;      // From dut of c3aibadapt_wrap.v
+    wire                HI;
+    wire                LO;
+    wire  [81*24-1:0]   ms_sideband;
+    wire  [73*24-1:0]   sl_sideband;              
     // End of automatics
    // EMIB Side
 // wire [95:0] AIB_CHAN0;
@@ -1561,6 +1560,9 @@ module top;
                     .o_tx_transfer_clk           (o_tx_transfer_clk), 
                     .o_tx_transfer_div2_clk      (o_tx_transfer_div2_clk),        // Not used 
                     .o_tx_pma_data               (o_tx_pma_data_24ch), 
+		    .ns_mac_rdy                  ({24{top_io.ns_mac_rdy}}),
+                    .ms_sideband                 (ms_sideband),
+		    .sl_sideband                 (sl_sideband),
                     .io_aib_ch0                  ({aib95_ch0_x0y0, aib94_ch0_x0y0, 1'b1,          aib94_ch0_x0y0,
                                                    aib91_ch0_x0y0, aib90_ch0_x0y0, aib89_ch0_x0y0,aib88_ch0_x0y0,
                                                    aib87_ch0_x0y0, aib86_ch0_x0y0, aib85_ch0_x0y0,aib84_ch0_x0y0,

--- a/how2use/sim_dcc/c3aibadapt_wrap.v
+++ b/how2use/sim_dcc/c3aibadapt_wrap.v
@@ -88,6 +88,12 @@ module c3aibadapt_wrap
 
     input                                      i_tx_elane_clk, //Clock for phase compensation fifo
     output [77:0]                              o_tx_elane_data,  //data out for phase compensation fifo
+   //=================================================================================================
+ //AIB open source IP enhancement. The following ports are added to b compliance with AIB specification 1.1
+    input                                      ns_mac_rdy,  //From Mac. To indicate MAC is ready to send and receive data. use aibio49
+    output [80:0]                              ms_sideband, //Status of serial shifting bit from this master chiplet to slave chiplet
+    output [72:0]                              sl_sideband, //Status of serial shifting bit from slave chiplet to master chiplet.                                                      
+  
  //=================================================================================================
  //// EMIB, AIB IO bumps
  
@@ -280,6 +286,20 @@ module c3aibadapt_wrap
     input [12:0]                               i_aibdftdll2adjch, // DCC/DLL observability from previous channel
     output [12:0]                              o_aibdftdll2adjch  // DCC/DLL observability Go to next channel 
  );
+
+    //List the detail bit assignment corresponding to the AIB spec 1.1
+    wire ms_osc_transfer_en = ms_sideband[80];
+    wire ms_tx_transfer_en = ms_sideband[78];
+    wire ms_rx_transfer_en = ms_sideband[75];
+    wire ms_rx_dll_lock = ms_sideband[74];
+    wire ms_tx_dcc_cal_done = ms_sideband[68];
+    wire sl_osc_transfer_en = sl_sideband[72]; 
+    wire sl_rx_transfer_en = sl_sideband[70];
+    wire sl_rx_dll_dcc_lock_req = sl_sideband[69];
+    wire sl_rx_dll_lock = sl_sideband[69];
+    wire sl_tx_transfer_en = sl_sideband[64];
+    wire sl_tx_dll_dcc_lock_req = sl_sideband[63];
+    wire sl_tx_dcc_cal_done = sl_sideband[31];
  
     /*AUTOWIRE*/
     // Beginning of automatic wires (for undeclared instantiated-module outputs)
@@ -590,7 +610,8 @@ module c3aibadapt_wrap
 
     .i_rx_elane_clk                         (i_rx_elane_clk),
     .i_tx_elane_clk                         (i_tx_elane_clk),
-    .i_rx_pma_div66_clk                     (1'b1),
+ // .i_rx_pma_div66_clk                     (1'b1),
+    .i_rx_pma_div66_clk                     (ns_mac_rdy),    //Added for AIB spec 1.1 enhancement. 6/12/19
     .i_tx_pma_div66_clk                     (1'b1),
     .i_rx_ehip_clk                          (1'b1),
      
@@ -753,6 +774,8 @@ module c3aibadapt_wrap
                            .o_tx_elane_rst_n    (),              // Templated
                            .o_chnl_ssr          (o_chnl_ssr[60:0]),
                            .o_chnl_fsr          (),              // Templated
+                           .ms_sideband         (ms_sideband[80:0]),
+                           .sl_sideband         (sl_sideband[72:0]),
                            .o_xcvrif_core_clk   (),              // Templated
                            .o_rx_xcvrif_rst_n   (o_rx_xcvrif_rst_n), // Templated
                            .o_rsvd_direct_async (),              // Templated
@@ -761,7 +784,7 @@ module c3aibadapt_wrap
                            .o_tx_transfer_div2_clk(o_tx_transfer_div2_clk),
                            // Inputs
                            .i_aib_rx_adpt_rst_n (aib_rx_adpt_rst_n), // Templated
-                           .i_aib_tx_adpt_rst_n (aib_tx_adpt_rst_n), // Templated
+                           .i_aib_tx_adpt_rst_n (aib_rx_adpt_rst_n), // Edit 6/16/19 Enhancement request: use only 1 AIB signal for resetting AIB adapter  
                            .i_aib_avmm1_data    (aib_adpt_avmm1_data[1:0]), // Templated
                            .i_aib_avmm2_data    (aib_adpt_avmm2_data[1:0]), // Templated
                            .i_aib_shared_direct_async(shared_direct_async_out[2:0]), // Templated

--- a/how2use/sim_dcc/dut_io.sv
+++ b/how2use/sim_dcc/dut_io.sv
@@ -10,6 +10,7 @@ interface dut_io (input bit i_osc_clk,
 
   
     logic                        i_adpt_hard_rst_n;
+    logic                        ns_mac_rdy;
     logic [6-1:0]                i_channel_id;
     logic                        i_cfg_avmm_rst_n;
     logic [16:0]                 i_cfg_avmm_addr;
@@ -82,6 +83,7 @@ interface dut_io (input bit i_osc_clk,
                 clocking cb_cfg_avmm,
                 clocking cb_rx_elane,
 		output i_adpt_hard_rst_n,
+                output ns_mac_rdy,
                 output i_cfg_avmm_rst_n);
     
 endinterface // dut_io

--- a/how2use/sim_dcc/test.sv
+++ b/how2use/sim_dcc/test.sv
@@ -44,6 +44,7 @@ program automatic test (dut_io.TB dut);
 	begin
 	    dut.i_adpt_hard_rst_n <= 1'b0;
             dut.i_cfg_avmm_rst_n  <= 1'b0;
+            dut.ns_mac_rdy <= 1'b0;
             
             err_count <= 0;
 
@@ -73,7 +74,8 @@ program automatic test (dut_io.TB dut);
             dut.i_cfg_avmm_rst_n  <= 1'b1;
             configuration_setup();
             $display ("[%t] Done configuration", $time);
-            
+            dut.ns_mac_rdy <= 1'b1; 
+            $display ("[%t] ns_mac_rdy is up. Clock should be stable prior to this", $time);
 	    repeat (random_dly_cycle) @ (posedge top.i_osc_clk);            
 	    dut.i_adpt_hard_rst_n <= 1'b1;
 	    $display("%0t: %m: de-asserting adapter hard reset", $time);

--- a/how2use/sim_dcc/top.sv
+++ b/how2use/sim_dcc/top.sv
@@ -10,11 +10,6 @@
 
 module top;
 
-    //------------------------------------------------------------------------------------------
-    // Dump control
-    initial begin
-    end
-
 
     //------------------------------------------------------------------------------------------
     // Clock generation
@@ -290,6 +285,10 @@ module top;
     wire                o_tx_xcvrif_rst_n;      // From dut of c3aibadapt_wrap.v
     wire                o_txen_out_chain1;      // From dut of c3aibadapt_wrap.v
     wire                o_txen_out_chain2;      // From dut of c3aibadapt_wrap.v
+    wire                HI;
+    wire                LO;
+    wire  [80:0]        ms_sideband;
+    wire  [72:0]        sl_sideband;              
     // End of automatics
 
     //-----------------------------------------------------------------------------------------
@@ -312,60 +311,6 @@ module top;
 
     //-----------------------------------------------------------------------------------------
     // DUT instantiation
-    // logic               rx_we = 1'b1;
-    // logic               tx_we = 1'b0;
-        
-    // assign aib20  = aib20_o;
-    // assign aib21  = aib21_o;
-    // assign aib22  = aib22_o;
-    // assign aib23  = aib23_o;
-    // assign aib24  = aib24_o;
-    // assign aib25  = aib25_o;
-    // assign aib26  = aib26_o;
-    // assign aib27  = aib27_o;
-    // assign aib28  = aib28_o;
-    // assign aib29  = aib29_o;
-    // assign aib30  = aib30_o;
-    // assign aib31  = aib31_o;
-    // assign aib32  = aib32_o;
-    // assign aib33  = aib33_o;
-    // assign aib34  = aib34_o;
-    // assign aib35  = aib35_o;
-    // assign aib36  = aib36_o;
-    // assign aib37  = aib37_o;
-    // assign aib38  = aib38_o;
-    // assign aib39  = aib39_o;
-
-    // assign aib43  = aib41_o;
-    // assign aib42  = aib40_o;
-    // assign aib84  = aib82_o;
-    // assign aib85  = aib83_o;
-    
-    // assign aib40_o = aib40;
-    // assign aib41_o = aib41;
-    // assign aib82_o = aib82;
-    // assign aib83_o = aib83;
-    
-    // assign aib20_o = aib0;
-    // assign aib21_o = aib1;
-    // assign aib22_o = aib2;
-    // assign aib23_o = aib3;
-    // assign aib24_o = aib4;
-    // assign aib25_o = aib5;
-    // assign aib26_o = aib6;
-    // assign aib27_o = aib7;
-    // assign aib28_o = aib8;
-    // assign aib29_o = aib9;
-    // assign aib30_o = aib10;
-    // assign aib31_o = aib11;
-    // assign aib32_o = aib12;
-    // assign aib33_o = aib13;
-    // assign aib34_o = aib14;
-    // assign aib35_o = aib15;
-    // assign aib36_o = aib16;
-    // assign aib37_o = aib17;
-    // assign aib38_o = aib18;
-    // assign aib39_o = aib19;
     
     c3aibadapt_wrap dut (/*AUTOINST*/
                          // Outputs
@@ -389,6 +334,9 @@ module top;
                          .o_tx_transfer_div2_clk(o_tx_transfer_div2_clk),
                          .o_tx_pma_data         (o_tx_pma_data[39:0]),
                          .o_tx_elane_data       (o_tx_elane_data[77:0]),
+                         .ns_mac_rdy            (top_io.ns_mac_rdy),
+                         .ms_sideband           (ms_sideband),
+                         .sl_sideband           (sl_sideband),
                          .o_test_c3adapt_scan_out(o_test_c3adapt_scan_out[`AIBADAPTWRAPTCB_SCAN_CHAINS_RNG]),
                          .o_test_c3adapttcb_jtag(o_test_c3adapttcb_jtag[`AIBADAPTWRAPTCB_JTAG_OUT_RNG]),
                          .o_jtag_clkdr_out      (o_jtag_clkdr_out),

--- a/how2use/sim_modelsim/dut_io.sv
+++ b/how2use/sim_modelsim/dut_io.sv
@@ -8,6 +8,7 @@ interface dut_io (input bit i_osc_clk,
 
   
     logic                        i_adpt_hard_rst_n;
+    logic                        ns_mac_rdy;
     logic [6-1:0]                i_channel_id;
     logic                        i_cfg_avmm_rst_n;
     logic [16:0]                 i_cfg_avmm_addr;
@@ -72,6 +73,7 @@ interface dut_io (input bit i_osc_clk,
 		clocking cb_rx_pma,
                 clocking cb_cfg_avmm,
 		output i_adpt_hard_rst_n,
+                output ns_mac_rdy,
                 output i_cfg_avmm_rst_n);
     
 endinterface // dut_io

--- a/how2use/sim_modelsim/test.sv
+++ b/how2use/sim_modelsim/test.sv
@@ -47,6 +47,7 @@ program automatic test (dut_io.TB dut);
 	begin
 	    dut.i_adpt_hard_rst_n <= 1'b0;
             dut.i_cfg_avmm_rst_n  <= 1'b0;
+            dut.ns_mac_rdy <= 1'b0;
             
             err_count <= 0;
 
@@ -77,7 +78,8 @@ program automatic test (dut_io.TB dut);
             dut.i_cfg_avmm_rst_n  <= 1'b1;
             configuration_setup();
             $display ("[%t] Done configuration", $time);
-            
+            dut.ns_mac_rdy <= 1'b1; 
+            $display ("[%t] ns_mac_rdy is up. Clock should be stable prior to this", $time);
 	    repeat (random_dly_cycle) @ (posedge top.i_osc_clk);            
 	    dut.i_adpt_hard_rst_n <= 1'b1;
 	    $display("%0t: %m: de-asserting adapter hard reset", $time);
@@ -233,8 +235,8 @@ program automatic test (dut_io.TB dut);
     // Wait for transfer ready before start pumping data
     //***************************************************
     task wait_xfer_ready();
-///Wei        wait (top.dut.c3aibadapt.adapt_rxchnl.rxrst_ctl.sr_fabric_rx_transfer_en);
-        wait (top.ndut.slave.aib_channel.aib_sm.sl_tx_transfer_en);
+        wait (top.dut.o_ehip_init_status[2:0] == 3'b111);
+
         
     endtask
     //************************************************

--- a/how2use/sim_modelsim/top.sv
+++ b/how2use/sim_modelsim/top.sv
@@ -8,16 +8,10 @@
 module top;
 
     //------------------------------------------------------------------------------------------
-    // Dump control
-    initial begin
-    end
-
-
-    //------------------------------------------------------------------------------------------
     // Clock generation
     
     parameter CFG_AVMM_CLK_PERIOD = 4000;
-    parameter OSC_CLK_PERIOD      = 10000;
+    parameter OSC_CLK_PERIOD      = 1000;
     parameter PMA_CLK_PERIOD      = 1000;
         
     reg   i_cfg_avmm_clk = 1'b0;
@@ -272,6 +266,10 @@ module top;
     wire                o_tx_xcvrif_rst_n;      // From dut of c3aibadapt_wrap.v
     wire                o_txen_out_chain1;      // From dut of c3aibadapt_wrap.v
     wire                o_txen_out_chain2;      // From dut of c3aibadapt_wrap.v
+    wire                HI;
+    wire                LO;
+    wire  [80:0]        ms_sideband;
+    wire  [72:0]        sl_sideband;              
     // End of automatics
 
     //-----------------------------------------------------------------------------------------
@@ -282,7 +280,7 @@ module top;
                    .i_tx_pma_clk (i_tx_pma_clk),
                    .i_cfg_avmm_clk (i_cfg_avmm_clk)
                    );
-//  ntop_io maib_io ();
+//  ndut_io maib_io ();
 
     //-----------------------------------------------------------------------------------------
     // Testbench instantiation
@@ -312,6 +310,9 @@ module top;
                          .o_tx_transfer_clk     (o_tx_transfer_clk),
                          .o_tx_transfer_div2_clk(o_tx_transfer_div2_clk),
                          .o_tx_pma_data         (o_tx_pma_data[39:0]),
+                         .ns_mac_rdy            (top_io.ns_mac_rdy),
+                         .ms_sideband           (ms_sideband),
+                         .sl_sideband           (sl_sideband),
                          .o_test_c3adapt_scan_out(o_test_c3adapt_scan_out[`AIBADAPTWRAPTCB_SCAN_CHAINS_RNG]),
                          .o_test_c3adapttcb_jtag(o_test_c3adapttcb_jtag[`AIBADAPTWRAPTCB_JTAG_OUT_RNG]),
                          .o_jtag_clkdr_out      (o_jtag_clkdr_out),
@@ -377,7 +378,8 @@ module top;
                          .io_aib42              (aib40),
                          .io_aib43              (aib41),
                          .io_aib44              (aib44),
-                         .io_aib45              (aib45),
+                         //.io_aib45              (aib45),
+                         .io_aib45              (HI), //From Tim's 3/26 aib_bump_map
                          .io_aib46              (aib46),
                          .io_aib47              (aib47),
                          .io_aib48              (aib48),
@@ -391,41 +393,55 @@ module top;
                          .io_aib55              (aib55),
                          .io_aib56              (aib56),
                          .io_aib57              (aib57),
-                         .io_aib58              (aib58),
+                         //.io_aib58              (aib58),
+                         .io_aib58              (LO), //From Tim's 3/26 aib_bump_map
                          .io_aib59              (aib59),
                          .io_aib6               (aib6 ),
                          .io_aib60              (aib60),
-                         .io_aib61              (aib61),
+                         //.io_aib61              (aib61),
+                         .io_aib61              (HI), //From Tim's 3/26 aib_bump_map
                          .io_aib62              (aib62),
-                         .io_aib63              (aib63),
-                         .io_aib64              (aib64),
+                         //.io_aib63              (aib63),
+                         .io_aib63              (LO), //From Tim's 3/26 aib_bump_map
+                         //.io_aib64              (aib64),
+                         .io_aib64              (LO), //From Tim's 3/26 aib_bump_map
                          .io_aib65              (aib65),
                          .io_aib66              (aib66),
-                         .io_aib67              (aib67),
+                         //.io_aib67              (aib67),
+                         .io_aib67              (LO), //From Tim's 3/26 aib_bump_map
                          .io_aib68              (aib68),
                          .io_aib69              (aib69),
                          .io_aib7               (aib7 ),
                          .io_aib70              (aib70),
                          .io_aib71              (aib71),
-                         .io_aib72              (aib72),
-                         .io_aib73              (aib73),
-                         .io_aib74              (aib74),
+                         //.io_aib72              (aib72),
+                         //.io_aib73              (aib73),
+                         //.io_aib74              (aib74),
+                         .io_aib72              (LO), //From Tim's 3/26 aib_bump_map
+                         .io_aib73              (LO), //From Tim's 3/26 aib_bump_map
+                         .io_aib74              (LO), //From Tim's 3/26 aib_bump_map
                          .io_aib75              (aib75),
                          .io_aib76              (aib76),
                          .io_aib77              (aib77),
-                         .io_aib78              (aib78),
-                         .io_aib79              (aib79),
+                         //.io_aib78              (aib78),
+                         //.io_aib79              (aib79),
+                         //.io_aib80              (aib80),
+                         //.io_aib81              (aib81),
+                         .io_aib78              (LO), //From Tim's 3/26 aib_bump_map
+                         .io_aib79              (LO), //From Tim's 3/26 aib_bump_map
                          .io_aib8               (aib8 ),
-                         .io_aib80              (aib80),
-                         .io_aib81              (aib81),
+                         .io_aib80              (LO), //From Tim's 3/26 aib_bump_map
+                         .io_aib81              (LO), //From Tim's 3/26 aib_bump_map
                          .io_aib82              (aib82),
                          .io_aib83              (aib83),
                          .io_aib84              (aib84),
                          .io_aib85              (aib85),
                          .io_aib86              (aib86),
                          .io_aib87              (aib87),
-                         .io_aib88              (aib88),
-                         .io_aib89              (aib89),
+                         //.io_aib88              (aib88),
+                         //.io_aib89              (aib89),
+                         .io_aib88              (LO), //From Tim's 3/26 aib_bump_map
+                         .io_aib89              (LO), //From Tim's 3/26 aib_bump_map
                          .io_aib9               (aib9 ),
                          .io_aib90              (aib90),
                          .io_aib91              (aib91),
@@ -446,7 +462,7 @@ module top;
                          .i_adpt_cfg_rdatavld   (top_io.i_adpt_cfg_rdatavld),
                          .i_adpt_cfg_rdata      (top_io.i_adpt_cfg_rdata[31:0]),
 //                       .i_adpt_cfg_waitreq    (top_io.i_adpt_cfg_waitreq),
-                         .i_adpt_cfg_waitreq    (1'b1),
+                         .i_adpt_cfg_waitreq    (HI),
                          .i_rx_pma_clk          (i_rx_pma_clk),
                          .i_rx_pma_div2_clk     (i_rx_pma_div2_clk),
                          .i_osc_clk             (i_osc_clk),

--- a/how2use/sim_phasecom/c3aibadapt_wrap.v
+++ b/how2use/sim_phasecom/c3aibadapt_wrap.v
@@ -88,6 +88,12 @@ module c3aibadapt_wrap
 
     input                                      i_tx_elane_clk, //Clock for phase compensation fifo
     output [77:0]                              o_tx_elane_data,  //data out for phase compensation fifo
+   //=================================================================================================
+ //AIB open source IP enhancement. The following ports are added to b compliance with AIB specification 1.1
+    input                                      ns_mac_rdy,  //From Mac. To indicate MAC is ready to send and receive data. use aibio49
+    output [80:0]                              ms_sideband, //Status of serial shifting bit from this master chiplet to slave chiplet
+    output [72:0]                              sl_sideband, //Status of serial shifting bit from slave chiplet to master chiplet.                                                      
+  
  //=================================================================================================
  //// EMIB, AIB IO bumps
  
@@ -280,6 +286,20 @@ module c3aibadapt_wrap
     input [12:0]                               i_aibdftdll2adjch, // DCC/DLL observability from previous channel
     output [12:0]                              o_aibdftdll2adjch  // DCC/DLL observability Go to next channel 
  );
+
+    //List the detail bit assignment corresponding to the AIB spec 1.1
+    wire ms_osc_transfer_en = ms_sideband[80];
+    wire ms_tx_transfer_en = ms_sideband[78];
+    wire ms_rx_transfer_en = ms_sideband[75];
+    wire ms_rx_dll_lock = ms_sideband[74];
+    wire ms_tx_dcc_cal_done = ms_sideband[68];
+    wire sl_osc_transfer_en = sl_sideband[72]; 
+    wire sl_rx_transfer_en = sl_sideband[70];
+    wire sl_rx_dll_dcc_lock_req = sl_sideband[69];
+    wire sl_rx_dll_lock = sl_sideband[69];
+    wire sl_tx_transfer_en = sl_sideband[64];
+    wire sl_tx_dll_dcc_lock_req = sl_sideband[63];
+    wire sl_tx_dcc_cal_done = sl_sideband[31];
  
     /*AUTOWIRE*/
     // Beginning of automatic wires (for undeclared instantiated-module outputs)
@@ -590,7 +610,8 @@ module c3aibadapt_wrap
 
     .i_rx_elane_clk                         (i_rx_elane_clk),
     .i_tx_elane_clk                         (i_tx_elane_clk),
-    .i_rx_pma_div66_clk                     (1'b1),
+ // .i_rx_pma_div66_clk                     (1'b1),
+    .i_rx_pma_div66_clk                     (ns_mac_rdy),    //Added for AIB spec 1.1 enhancement. 6/12/19
     .i_tx_pma_div66_clk                     (1'b1),
     .i_rx_ehip_clk                          (1'b1),
      
@@ -753,6 +774,8 @@ module c3aibadapt_wrap
                            .o_tx_elane_rst_n    (),              // Templated
                            .o_chnl_ssr          (o_chnl_ssr[60:0]),
                            .o_chnl_fsr          (),              // Templated
+                           .ms_sideband         (ms_sideband[80:0]),
+                           .sl_sideband         (sl_sideband[72:0]),
                            .o_xcvrif_core_clk   (),              // Templated
                            .o_rx_xcvrif_rst_n   (o_rx_xcvrif_rst_n), // Templated
                            .o_rsvd_direct_async (),              // Templated
@@ -761,7 +784,7 @@ module c3aibadapt_wrap
                            .o_tx_transfer_div2_clk(o_tx_transfer_div2_clk),
                            // Inputs
                            .i_aib_rx_adpt_rst_n (aib_rx_adpt_rst_n), // Templated
-                           .i_aib_tx_adpt_rst_n (aib_tx_adpt_rst_n), // Templated
+                           .i_aib_tx_adpt_rst_n (aib_rx_adpt_rst_n), // Edit 6/16/19 Enhancement request: use only 1 AIB signal for resetting AIB adapter  
                            .i_aib_avmm1_data    (aib_adpt_avmm1_data[1:0]), // Templated
                            .i_aib_avmm2_data    (aib_adpt_avmm2_data[1:0]), // Templated
                            .i_aib_shared_direct_async(shared_direct_async_out[2:0]), // Templated

--- a/how2use/sim_phasecom/dut_io.sv
+++ b/how2use/sim_phasecom/dut_io.sv
@@ -10,6 +10,7 @@ interface dut_io (input bit i_osc_clk,
 
   
     logic                        i_adpt_hard_rst_n;
+    logic                        ns_mac_rdy;
     logic [6-1:0]                i_channel_id;
     logic                        i_cfg_avmm_rst_n;
     logic [16:0]                 i_cfg_avmm_addr;
@@ -82,6 +83,7 @@ interface dut_io (input bit i_osc_clk,
                 clocking cb_cfg_avmm,
                 clocking cb_rx_elane,
 		output i_adpt_hard_rst_n,
+                output ns_mac_rdy,
                 output i_cfg_avmm_rst_n);
     
 endinterface // dut_io

--- a/how2use/sim_phasecom/test.sv
+++ b/how2use/sim_phasecom/test.sv
@@ -44,6 +44,7 @@ program automatic test (dut_io.TB dut);
 	begin
 	    dut.i_adpt_hard_rst_n <= 1'b0;
             dut.i_cfg_avmm_rst_n  <= 1'b0;
+            dut.ns_mac_rdy <= 1'b0;
             
             err_count <= 0;
 
@@ -73,7 +74,8 @@ program automatic test (dut_io.TB dut);
             dut.i_cfg_avmm_rst_n  <= 1'b1;
             configuration_setup();
             $display ("[%t] Done configuration", $time);
-            
+            dut.ns_mac_rdy <= 1'b1; 
+            $display ("[%t] ns_mac_rdy is up. Clock should be stable prior to this", $time);
 	    repeat (random_dly_cycle) @ (posedge top.i_osc_clk);            
 	    dut.i_adpt_hard_rst_n <= 1'b1;
 	    $display("%0t: %m: de-asserting adapter hard reset", $time);

--- a/how2use/sim_phasecom/top.sv
+++ b/how2use/sim_phasecom/top.sv
@@ -10,11 +10,6 @@
 
 module top;
 
-    //------------------------------------------------------------------------------------------
-    // Dump control
-    initial begin
-    end
-
 
     //------------------------------------------------------------------------------------------
     // Clock generation
@@ -279,6 +274,10 @@ module top;
     wire                o_tx_xcvrif_rst_n;      // From dut of c3aibadapt_wrap.v
     wire                o_txen_out_chain1;      // From dut of c3aibadapt_wrap.v
     wire                o_txen_out_chain2;      // From dut of c3aibadapt_wrap.v
+    wire                HI;
+    wire                LO;
+    wire  [80:0]        ms_sideband;
+    wire  [72:0]        sl_sideband;              
     // End of automatics
 
     //-----------------------------------------------------------------------------------------
@@ -301,60 +300,6 @@ module top;
 
     //-----------------------------------------------------------------------------------------
     // DUT instantiation
-    // logic               rx_we = 1'b1;
-    // logic               tx_we = 1'b0;
-        
-    // assign aib20  = aib20_o;
-    // assign aib21  = aib21_o;
-    // assign aib22  = aib22_o;
-    // assign aib23  = aib23_o;
-    // assign aib24  = aib24_o;
-    // assign aib25  = aib25_o;
-    // assign aib26  = aib26_o;
-    // assign aib27  = aib27_o;
-    // assign aib28  = aib28_o;
-    // assign aib29  = aib29_o;
-    // assign aib30  = aib30_o;
-    // assign aib31  = aib31_o;
-    // assign aib32  = aib32_o;
-    // assign aib33  = aib33_o;
-    // assign aib34  = aib34_o;
-    // assign aib35  = aib35_o;
-    // assign aib36  = aib36_o;
-    // assign aib37  = aib37_o;
-    // assign aib38  = aib38_o;
-    // assign aib39  = aib39_o;
-
-    // assign aib43  = aib41_o;
-    // assign aib42  = aib40_o;
-    // assign aib84  = aib82_o;
-    // assign aib85  = aib83_o;
-    
-    // assign aib40_o = aib40;
-    // assign aib41_o = aib41;
-    // assign aib82_o = aib82;
-    // assign aib83_o = aib83;
-    
-    // assign aib20_o = aib0;
-    // assign aib21_o = aib1;
-    // assign aib22_o = aib2;
-    // assign aib23_o = aib3;
-    // assign aib24_o = aib4;
-    // assign aib25_o = aib5;
-    // assign aib26_o = aib6;
-    // assign aib27_o = aib7;
-    // assign aib28_o = aib8;
-    // assign aib29_o = aib9;
-    // assign aib30_o = aib10;
-    // assign aib31_o = aib11;
-    // assign aib32_o = aib12;
-    // assign aib33_o = aib13;
-    // assign aib34_o = aib14;
-    // assign aib35_o = aib15;
-    // assign aib36_o = aib16;
-    // assign aib37_o = aib17;
-    // assign aib38_o = aib18;
-    // assign aib39_o = aib19;
     
     c3aibadapt_wrap dut (/*AUTOINST*/
                          // Outputs
@@ -378,6 +323,9 @@ module top;
                          .o_tx_transfer_div2_clk(o_tx_transfer_div2_clk),
                          .o_tx_pma_data         (o_tx_pma_data[39:0]),
                          .o_tx_elane_data       (o_tx_elane_data[77:0]),
+                         .ns_mac_rdy            (top_io.ns_mac_rdy),
+                         .ms_sideband           (ms_sideband),
+                         .sl_sideband           (sl_sideband),
                          .o_test_c3adapt_scan_out(o_test_c3adapt_scan_out[`AIBADAPTWRAPTCB_SCAN_CHAINS_RNG]),
                          .o_test_c3adapttcb_jtag(o_test_c3adapttcb_jtag[`AIBADAPTWRAPTCB_JTAG_OUT_RNG]),
                          .o_jtag_clkdr_out      (o_jtag_clkdr_out),

--- a/ndsimslv/dut_io.sv
+++ b/ndsimslv/dut_io.sv
@@ -9,6 +9,7 @@ interface dut_io (input bit i_osc_clk,
 
   
     logic                        i_adpt_hard_rst_n;
+    logic                        ns_mac_rdy;
     logic [6-1:0]                i_channel_id;
     logic                        i_cfg_avmm_rst_n;
     logic [16:0]                 i_cfg_avmm_addr;
@@ -73,6 +74,7 @@ interface dut_io (input bit i_osc_clk,
 		clocking cb_rx_pma,
                 clocking cb_cfg_avmm,
 		output i_adpt_hard_rst_n,
+                output ns_mac_rdy,
                 output i_cfg_avmm_rst_n);
     
 endinterface // dut_io

--- a/ndsimslv/test.sv
+++ b/ndsimslv/test.sv
@@ -47,6 +47,7 @@ program automatic test (dut_io.TB dut);
 	begin
 	    dut.i_adpt_hard_rst_n <= 1'b0;
             dut.i_cfg_avmm_rst_n  <= 1'b0;
+            dut.ns_mac_rdy <= 1'b0;
             
             err_count <= 0;
 
@@ -77,7 +78,8 @@ program automatic test (dut_io.TB dut);
             dut.i_cfg_avmm_rst_n  <= 1'b1;
             configuration_setup();
             $display ("[%t] Done configuration", $time);
-            
+            dut.ns_mac_rdy <= 1'b1; 
+            $display ("[%t] ns_mac_rdy is up. Clock should be stable prior to this", $time);
 	    repeat (random_dly_cycle) @ (posedge top.i_osc_clk);            
 	    dut.i_adpt_hard_rst_n <= 1'b1;
 	    $display("%0t: %m: de-asserting adapter hard reset", $time);

--- a/ndsimslv/top.sv
+++ b/ndsimslv/top.sv
@@ -7,11 +7,6 @@
 
 module top;
 
-    //------------------------------------------------------------------------------------------
-    // Dump control
-    initial begin
-    end
-
 
     //------------------------------------------------------------------------------------------
     // Clock generation
@@ -274,6 +269,8 @@ module top;
     wire                o_txen_out_chain2;      // From dut of c3aibadapt_wrap.v
     wire                HI;
     wire                LO;
+    wire  [80:0]        ms_sideband;
+    wire  [72:0]        sl_sideband;              
     // End of automatics
 
     //-----------------------------------------------------------------------------------------
@@ -314,6 +311,9 @@ module top;
                          .o_tx_transfer_clk     (o_tx_transfer_clk),
                          .o_tx_transfer_div2_clk(o_tx_transfer_div2_clk),
                          .o_tx_pma_data         (o_tx_pma_data[39:0]),
+                         .ns_mac_rdy            (top_io.ns_mac_rdy),
+                         .ms_sideband           (ms_sideband),
+                         .sl_sideband           (sl_sideband),
                          .o_test_c3adapt_scan_out(o_test_c3adapt_scan_out[`AIBADAPTWRAPTCB_SCAN_CHAINS_RNG]),
                          .o_test_c3adapttcb_jtag(o_test_c3adapttcb_jtag[`AIBADAPTWRAPTCB_JTAG_OUT_RNG]),
                          .o_jtag_clkdr_out      (o_jtag_clkdr_out),


### PR DESCRIPTION
1) Use only 1 AIB signal for resetting AIB adapter
2) Expose ns_mac_rdy as an input at each module port up through aib_top and individual channel.
3) For all channels [23:0] expose the slave to master incoming shift register at aib_top, PHY-->MAC
4) For all channels [23:0] expose the master to slave bits corresponding to the outgoing shift registe

Signed-off-by: huizhan1 <julie.zhang@intel.com>